### PR TITLE
feat: warn if project exists already

### DIFF
--- a/src/tests/e2e/e2e-testing.spec.ts
+++ b/src/tests/e2e/e2e-testing.spec.ts
@@ -73,6 +73,10 @@ describe("E2E", () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+
+    if (fs.existsSync(projectDirectory)) {
+      fs.rmSync(projectDirectory, { recursive: true });
+    }
   });
 
   it("should be neat", async () => {


### PR DESCRIPTION
## Description

- [x] improve experience in the first step, especially if the destination directory is already a poto-project

## Related Issue

Closes #29

## Type of change

- [ ] Chore
- [ ] Bug fix
- [ ] New feature
- [x] Feature change
- [ ] Breaking change
- [ ] Documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
